### PR TITLE
fix select styling

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -68,7 +68,7 @@
                   <div class="sign-up" id="sign-up-form">
                 <%= form_for :user, :url => users_path, :remote=>true, :id => 'create_new_user' do |f| %>
                   <div class="form-group">
-                    <%= f.select(:hotel_name, options_for_select([["Select Your Hotel",""],["Marriott","Marriott"],["Sheraton","Sheraton"],["Hilton","Hilton"],["Hyatt Regency","Hyatt Regency"],["Crowne Plaza","Crowne Plaza"],["Holiday Inn","Holiday Inn"]]), class: "custom-select form-control") %>
+                    <%= f.select(:hotel_name, options_for_select([["Select Your Hotel",""],["Marriott","Marriott"],["Sheraton","Sheraton"],["Hilton","Hilton"],["Hyatt Regency","Hyatt Regency"],["Crowne Plaza","Crowne Plaza"],["Holiday Inn","Holiday Inn"]]), {}, class: "custom-select form-control") %>
                   </div>
                   <div class="form-group position-relative">
                     <%= f.label :nickname, "Choose A Nickname", class: "control-label-hide", id: "nickNameLabel" %>


### PR DESCRIPTION
Select helper takes two options hashes, one for select, and the second for html options. select(object, method, choices = nil, options = {}, html_options = {}, &block)
http://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select